### PR TITLE
Remove the superfluous ProGuard rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ If you try to use a database encrypted with a SqlCipher version lower than 4, th
 If using ProGuard, add the following rules:
 ```
 -keep class net.sqlcipher.** { *; }
--keep class net.sqlcipher.database.* { *; }
 ```
 
 ---


### PR DESCRIPTION
See:
https://github.com/sqlcipher/android-database-sqlcipher/commit/f19ceb0f0d703d6f449b8531d1d75ae66bbfd0fc

Or fix it as: (Add a *)
```
-keep class net.sqlcipher.** { *; }
-keep class net.sqlcipher.database.** { *; }
```