### PR TITLE
Fix crash when normal sqflite is being used

### DIFF
--- a/sqflite/CHANGELOG.md
+++ b/sqflite/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.1.3
+
+* Update SQLCipher version to [4.4.2](https://www.zetetic.net/blog/2020/11/25/sqlcipher-442-release/)
+
+## 1.1.2
+
+* Update SQLCipher version to [4.4.1](https://www.zetetic.net/blog/2020/11/06/sqlcipher-441-release/)
+* Fix Handler constructor deprecation
+
+## 1.1.1
+
+* Remove unnecessary logs
+
 ## 1.1.0+1
 
 * Update SQLCipher version to [4.4.0](https://www.zetetic.net/blog/2020/05/12/sqlcipher-440-release/)

--- a/sqflite/android/build.gradle
+++ b/sqflite/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:4.1.0'
     }
 }
 
@@ -30,7 +30,7 @@ allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 16
@@ -43,6 +43,6 @@ android {
 
 dependencies {
     implementation fileTree(include: '*.jar', dir: 'libs')
-    implementation 'net.zetetic:android-database-sqlcipher:4.4.0'
-    testImplementation 'junit:junit:4.12'
+    implementation 'net.zetetic:android-database-sqlcipher:4.4.2'
+    testImplementation 'junit:junit:4.13.1'
 }

--- a/sqflite/android/src/main/java/com/davidmartos96/sqflite_sqlcipher/SqfliteSqlCipherPlugin.java
+++ b/sqflite/android/src/main/java/com/davidmartos96/sqflite_sqlcipher/SqfliteSqlCipherPlugin.java
@@ -10,6 +10,7 @@ import net.sqlcipher.database.SQLiteDatabase;
 import android.database.sqlite.SQLiteCantOpenDatabaseException;
 import android.os.Handler;
 import android.os.HandlerThread;
+import android.os.Looper;
 import android.os.Process;
 import android.util.Log;
 
@@ -103,7 +104,8 @@ public class SqfliteSqlCipherPlugin implements FlutterPlugin, MethodCallHandler 
     //
     // Plugin registration.
     //
-    public static void registerWith(Registrar registrar) {
+    @SuppressWarnings("deprecation")
+    public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
         SqfliteSqlCipherPlugin sqflitePlugin = new SqfliteSqlCipherPlugin();
         sqflitePlugin.onAttachedToEngine(registrar.context(), registrar.messenger());
     }
@@ -1052,7 +1054,7 @@ public class SqfliteSqlCipherPlugin implements FlutterPlugin, MethodCallHandler 
 
     private class BgResult implements Result {
         // Caller handler
-        final Handler handler = new Handler();
+        final Handler handler = new Handler(Looper.getMainLooper());
         private final Result result;
 
         private BgResult(Result result) {

--- a/sqflite/example/android/app/build.gradle
+++ b/sqflite/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     lintOptions {
         disable 'InvalidPackage'
@@ -33,7 +33,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/sqflite/example/android/build.gradle
+++ b/sqflite/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:4.1.0'
     }
 }
 

--- a/sqflite/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/sqflite/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Mar 14 12:30:38 CET 2020
+#Sun Nov 08 13:21:57 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/sqflite/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/sqflite/example/ios/Runner.xcodeproj/project.pbxproj
@@ -267,6 +267,7 @@
 				"${PODS_ROOT}/../Flutter/Flutter.framework",
 				"${BUILT_PRODUCTS_DIR}/SQLCipher/SQLCipher.framework",
 				"${BUILT_PRODUCTS_DIR}/e2e/e2e.framework",
+				"${BUILT_PRODUCTS_DIR}/sqflite/sqflite.framework",
 				"${BUILT_PRODUCTS_DIR}/sqflite_sqlcipher/sqflite_sqlcipher.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -275,6 +276,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SQLCipher.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/e2e.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/sqflite.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/sqflite_sqlcipher.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/sqflite/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/sqflite/example/ios/Runner.xcodeproj/project.pbxproj
@@ -9,11 +9,7 @@
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
-		3B80C3941E831B6300D905FE /* App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; };
-		3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
-		9705A1C61CF904A100538489 /* Flutter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; };
-		9705A1C71CF904A300538489 /* Flutter.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
@@ -27,8 +23,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */,
-				9705A1C71CF904A300538489 /* Flutter.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -40,7 +34,6 @@
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		239781ACEA94A0576DAE40B2 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		3B80C3931E831B6300D905FE /* App.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = App.framework; path = Flutter/App.framework; sourceTree = "<group>"; };
 		421DFDD0B26DF78679F3B3FD /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		4553649FCD359304DDF866B8 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -48,7 +41,6 @@
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
-		9740EEBA1CF902C7004384FC /* Flutter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Flutter.framework; path = Flutter/Flutter.framework; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		97C146FB1CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -62,8 +54,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9705A1C61CF904A100538489 /* Flutter.framework in Frameworks */,
-				3B80C3941E831B6300D905FE /* App.framework in Frameworks */,
 				DEE50469E055C9BA68FBE0B3 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -82,9 +72,7 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
-				3B80C3931E831B6300D905FE /* App.framework */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
-				9740EEBA1CF902C7004384FC /* Flutter.framework */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
 				9740EEB31CF90195004384FC /* Generated.xcconfig */,
@@ -252,7 +240,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" thin";
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -274,9 +262,20 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/FMDB/FMDB.framework",
+				"${PODS_ROOT}/../Flutter/Flutter.framework",
+				"${BUILT_PRODUCTS_DIR}/SQLCipher/SQLCipher.framework",
+				"${BUILT_PRODUCTS_DIR}/e2e/e2e.framework",
+				"${BUILT_PRODUCTS_DIR}/sqflite_sqlcipher/sqflite_sqlcipher.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FMDB.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SQLCipher.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/e2e.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/sqflite_sqlcipher.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -319,7 +318,6 @@
 /* Begin XCBuildConfiguration section */
 		249021D3217E4FDB00AE95B9 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -396,7 +394,6 @@
 		};
 		97C147031CF9000F007C117D /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -452,7 +449,6 @@
 		};
 		97C147041CF9000F007C117D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/sqflite/example/pubspec.yaml
+++ b/sqflite/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sqflite_sqlcipher_example
 description: Demonstrates how to use the sqflite plugin.
 publish_to: none
-version: '0.2.0'
+version: "0.2.0"
 
 environment:
   sdk: ">=2.7.0-dev <3.0.0"
@@ -16,11 +16,10 @@ dependencies:
     path: ../
   sqflite:
     git:
-      url: https://www.github.com/daohoangson/sqflite_sqlcipher.git
+      url: https://www.github.com/davidmartos96/sqflite_sqlcipher.git
       path: sqflite
       ref: fmdb_override
   synchronized: ^2.2.0
-
 
 dev_dependencies:
   flutter_test:
@@ -29,16 +28,15 @@ dev_dependencies:
     sdk: flutter
   e2e: ^0.2.1
   test:
-  matcher: '>=0.12.3 < 2.0.0'
-  pedantic: '>=1.4.0 <3.0.0'
-  process_run: '>=0.10.0'
+  matcher: ">=0.12.3 < 2.0.0"
+  pedantic: ">=1.4.0 <3.0.0"
+  process_run: ">=0.10.0"
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec
 
 # The following section is specific to Flutter.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the Icons class.

--- a/sqflite/example/pubspec.yaml
+++ b/sqflite/example/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
     path: ../
   sqflite:
     git:
-      url: https://www.github.com/davidmartos96/sqflite_sqlcipher.git
+      url: https://www.github.com/daohoangson/sqflite_sqlcipher.git
       path: sqflite
       ref: fmdb_override
   synchronized: ^2.2.0

--- a/sqflite/ios/Classes/SqfliteSqlCipherOperation.h
+++ b/sqflite/ios/Classes/SqfliteSqlCipherOperation.h
@@ -6,10 +6,10 @@
 //
 #import "SqfliteSqlCipherPlugin.h"
 
-#ifndef SqfliteOperation_h
-#define SqfliteOperation_h
+#ifndef SqfliteSqlCipherOperation_h
+#define SqfliteSqlCipherOperation_h
 
-@interface SqfliteOperation : NSObject
+@interface SqfliteSqlCipherOperation : NSObject
 
 - (NSString*)getMethod;
 - (NSString*)getSql;
@@ -22,7 +22,7 @@
 
 @end
 
-@interface SqfliteBatchOperation : SqfliteOperation
+@interface SqfliteSqlCipherBatchOperation : SqfliteSqlCipherOperation
 
 @property (atomic, retain) NSDictionary* dictionary;
 @property (atomic, retain) NSObject* results;
@@ -36,13 +36,13 @@
 
 @end
 
-@interface SqfliteMethodCallOperation : SqfliteOperation
+@interface SqfliteSqlCipherMethodCallOperation : SqfliteSqlCipherOperation
 
 @property (atomic, retain) FlutterMethodCall* flutterMethodCall;
 @property (atomic, assign) FlutterResult flutterResult;
 
-+ (SqfliteMethodCallOperation*)newWithCall:(FlutterMethodCall*)flutterMethodCall result:(FlutterResult)flutterResult;
++ (SqfliteSqlCipherMethodCallOperation*)newWithCall:(FlutterMethodCall*)flutterMethodCall result:(FlutterResult)flutterResult;
 
 @end
 
-#endif /* SqfliteOperation_h */
+#endif /* SqfliteSqlCipherOperation_h */

--- a/sqflite/ios/Classes/SqfliteSqlCipherOperation.m
+++ b/sqflite/ios/Classes/SqfliteSqlCipherOperation.m
@@ -6,11 +6,11 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "SqfliteOperation.h"
+#import "SqfliteSqlCipherOperation.h"
 #import "SqfliteSqlCipherPlugin.h"
 
 // Abstract
-@implementation SqfliteOperation
+@implementation SqfliteSqlCipherOperation
 
 - (NSString*)getMethod {
     return  nil;
@@ -36,25 +36,25 @@
 
 @end
 
-@implementation SqfliteBatchOperation
+@implementation SqfliteSqlCipherBatchOperation
 
 @synthesize dictionary, results, error, noResult, continueOnError;
 
 - (NSString*)getMethod {
-    return [dictionary objectForKey:SqfliteParamMethod];
+    return [dictionary objectForKey:SqfliteSqlCipherParamMethod];
 }
 
 - (NSString*)getSql {
-    return [dictionary objectForKey:SqfliteParamSql];
+    return [dictionary objectForKey:SqfliteSqlCipherParamSql];
 }
 
 - (NSArray*)getSqlArguments {
-    NSArray* arguments = [dictionary objectForKey:SqfliteParamSqlArguments];
+    NSArray* arguments = [dictionary objectForKey:SqfliteSqlCipherParamSqlArguments];
     return [SqfliteSqlCipherPlugin toSqlArguments:arguments];
 }
 
 - (NSNumber*)getInTransactionArgument {
-    return [dictionary objectForKey:SqfliteParamInTransaction];
+    return [dictionary objectForKey:SqfliteSqlCipherParamInTransaction];
 }
 
 - (bool)getNoResult {
@@ -77,7 +77,7 @@
     if (![self getNoResult]) {
         // We wrap the result in 'result' map
         [results addObject:[NSDictionary dictionaryWithObject:((self.results == nil) ? [NSNull null] : self.results)
-                                                       forKey:SqfliteParamResult]];
+                                                       forKey:SqfliteSqlCipherParamResult]];
     }
 }
 
@@ -86,15 +86,15 @@
     if (![self getNoResult]) {
         // We wrap the error in an 'error' map
         NSMutableDictionary* error = [NSMutableDictionary new];
-        error[SqfliteParamErrorCode] = self.error.code;
+        error[SqfliteSqlCipherParamErrorCode] = self.error.code;
         if (self.error.message != nil) {
-            error[SqfliteParamErrorMessage] = self.error.message;
+            error[SqfliteSqlCipherParamErrorMessage] = self.error.message;
         }
         if (self.error.details != nil) {
-            error[SqfliteParamErrorData] = self.error.details;
+            error[SqfliteSqlCipherParamErrorData] = self.error.details;
         }
         [results addObject:[NSDictionary dictionaryWithObject:error
-                                                       forKey:SqfliteParamError]];
+                                                       forKey:SqfliteSqlCipherParamError]];
     }
 }
 
@@ -104,13 +104,13 @@
 
 @end
 
-@implementation SqfliteMethodCallOperation
+@implementation SqfliteSqlCipherMethodCallOperation
 
 @synthesize flutterMethodCall;
 @synthesize flutterResult;
 
-+ (SqfliteMethodCallOperation*)newWithCall:(FlutterMethodCall*)flutterMethodCall result:(FlutterResult)flutterResult {
-    SqfliteMethodCallOperation* operation = [SqfliteMethodCallOperation new];
++ (SqfliteSqlCipherMethodCallOperation*)newWithCall:(FlutterMethodCall*)flutterMethodCall result:(FlutterResult)flutterResult {
+    SqfliteSqlCipherMethodCallOperation* operation = [SqfliteSqlCipherMethodCallOperation new];
     operation.flutterMethodCall = flutterMethodCall;
     operation.flutterResult = flutterResult;
     return operation;
@@ -121,26 +121,26 @@
 }
 
 - (NSString*)getSql {
-    return flutterMethodCall.arguments[SqfliteParamSql];
+    return flutterMethodCall.arguments[SqfliteSqlCipherParamSql];
 }
 
 - (bool)getNoResult {
-    NSNumber* noResult = flutterMethodCall.arguments[SqfliteParamNoResult];
+    NSNumber* noResult = flutterMethodCall.arguments[SqfliteSqlCipherParamNoResult];
     return [noResult boolValue];
 }
 
 - (bool)getContinueOnError {
-    NSNumber* noResult = flutterMethodCall.arguments[SqfliteParamContinueOnError];
+    NSNumber* noResult = flutterMethodCall.arguments[SqfliteSqlCipherParamContinueOnError];
     return [noResult boolValue];
 }
 
 - (NSArray*)getSqlArguments {
-    NSArray* arguments = flutterMethodCall.arguments[SqfliteParamSqlArguments];
+    NSArray* arguments = flutterMethodCall.arguments[SqfliteSqlCipherParamSqlArguments];
     return [SqfliteSqlCipherPlugin toSqlArguments:arguments];
 }
 
 - (NSNumber*)getInTransactionArgument {
-    return flutterMethodCall.arguments[SqfliteParamInTransaction];
+    return flutterMethodCall.arguments[SqfliteSqlCipherParamInTransaction];
 }
 
 - (void)success:(NSObject*)results {

--- a/sqflite/ios/Classes/SqfliteSqlCipherPlugin.h
+++ b/sqflite/ios/Classes/SqfliteSqlCipherPlugin.h
@@ -10,14 +10,14 @@
 
 @end
 
-extern NSString *const SqfliteParamMethod;
-extern NSString *const SqfliteParamSql;
-extern NSString *const SqfliteParamSqlArguments;
-extern NSString *const SqfliteParamInTransaction;
-extern NSString *const SqfliteParamNoResult;
-extern NSString *const SqfliteParamContinueOnError;
-extern NSString *const SqfliteParamResult;
-extern NSString *const SqfliteParamError;
-extern NSString *const SqfliteParamErrorCode;
-extern NSString *const SqfliteParamErrorMessage;
-extern NSString *const SqfliteParamErrorData;
+extern NSString *const SqfliteSqlCipherParamMethod;
+extern NSString *const SqfliteSqlCipherParamSql;
+extern NSString *const SqfliteSqlCipherParamSqlArguments;
+extern NSString *const SqfliteSqlCipherParamInTransaction;
+extern NSString *const SqfliteSqlCipherParamNoResult;
+extern NSString *const SqfliteSqlCipherParamContinueOnError;
+extern NSString *const SqfliteSqlCipherParamResult;
+extern NSString *const SqfliteSqlCipherParamError;
+extern NSString *const SqfliteSqlCipherParamErrorCode;
+extern NSString *const SqfliteSqlCipherParamErrorMessage;
+extern NSString *const SqfliteSqlCipherParamErrorData;

--- a/sqflite/ios/Classes/SqfliteSqlCipherPlugin.m
+++ b/sqflite/ios/Classes/SqfliteSqlCipherPlugin.m
@@ -8,7 +8,7 @@
 #endif
 
 #import <sqlite3.h>
-#import "SqfliteOperation.h"
+#import "SqfliteSqlCipherOperation.h"
 
 static NSString *const _channelName = @"com.davidmartos96.sqflite_sqlcipher";
 static NSString *const _inMemoryPath = @":memory:";
@@ -58,21 +58,21 @@ static NSString *const _paramCmd = @"cmd";
 static NSString *const _paramCmdGet = @"get";
 
 // Shared
-NSString *const SqfliteParamSql = @"sql";
-NSString *const SqfliteParamSqlArguments = @"arguments";
-NSString *const SqfliteParamInTransaction = @"inTransaction"; // true, false or null
-NSString *const SqfliteParamNoResult = @"noResult";
-NSString *const SqfliteParamContinueOnError = @"continueOnError";
-NSString *const SqfliteParamMethod = @"method";
+NSString *const SqfliteSqlCipherParamSql = @"sql";
+NSString *const SqfliteSqlCipherParamSqlArguments = @"arguments";
+NSString *const SqfliteSqlCipherParamInTransaction = @"inTransaction"; // true, false or null
+NSString *const SqfliteSqlCipherParamNoResult = @"noResult";
+NSString *const SqfliteSqlCipherParamContinueOnError = @"continueOnError";
+NSString *const SqfliteSqlCipherParamMethod = @"method";
 // For each operation in a batch, we have either a result or an error
-NSString *const SqfliteParamResult = @"result";
-NSString *const SqfliteParamError = @"error";
-NSString *const SqfliteParamErrorCode = @"code";
-NSString *const SqfliteParamErrorMessage = @"message";
-NSString *const SqfliteParamErrorData = @"data";
+NSString *const SqfliteSqlCipherParamResult = @"result";
+NSString *const SqfliteSqlCipherParamError = @"error";
+NSString *const SqfliteSqlCipherParamErrorCode = @"code";
+NSString *const SqfliteSqlCipherParamErrorMessage = @"message";
+NSString *const SqfliteSqlCipherParamErrorData = @"data";
 
 
-@interface SqfliteDatabase : NSObject
+@interface SqfliteSqlCipherDatabase : NSObject
 
 @property (atomic, retain) FMDatabaseQueue *fmDatabaseQueue;
 @property (atomic, retain) NSNumber *databaseId;
@@ -85,13 +85,13 @@ NSString *const SqfliteParamErrorData = @"data";
 
 @interface SqfliteSqlCipherPlugin ()
 
-@property (atomic, retain) NSMutableDictionary<NSNumber*, SqfliteDatabase*>* databaseMap;
-@property (atomic, retain) NSMutableDictionary<NSString*, SqfliteDatabase*>* singleInstanceDatabaseMap;
+@property (atomic, retain) NSMutableDictionary<NSNumber*, SqfliteSqlCipherDatabase*>* databaseMap;
+@property (atomic, retain) NSMutableDictionary<NSString*, SqfliteSqlCipherDatabase*>* singleInstanceDatabaseMap;
 @property (atomic, retain) NSObject* mapLock;
 
 @end
 
-@implementation SqfliteDatabase
+@implementation SqfliteSqlCipherDatabase
 
 @synthesize databaseId;
 @synthesize fmDatabaseQueue;
@@ -147,9 +147,9 @@ static NSInteger _databaseOpenCount = 0;
     return self;
 }
 
-- (SqfliteDatabase *)getDatabaseOrError:(FlutterMethodCall*)call result:(FlutterResult)result {
+- (SqfliteSqlCipherDatabase *)getDatabaseOrError:(FlutterMethodCall*)call result:(FlutterResult)result {
     NSNumber* databaseId = call.arguments[_paramId];
-    SqfliteDatabase* database = self.databaseMap[databaseId];
+    SqfliteSqlCipherDatabase* database = self.databaseMap[databaseId];
     if (database == nil) {
         NSLog(@"db not found.");
         result([FlutterError errorWithCode:_sqliteErrorCode
@@ -171,17 +171,17 @@ static NSInteger _databaseOpenCount = 0;
     return NO;
 }
 
-- (BOOL)handleError:(FMDatabase*)db operation:(SqfliteOperation*)operation {
+- (BOOL)handleError:(FMDatabase*)db operation:(SqfliteSqlCipherOperation*)operation {
     // handle error
     if ([db hadError]) {
         NSMutableDictionary* details = nil;
         NSString* sql = [operation getSql];
         if (sql != nil) {
             details = [NSMutableDictionary new];
-            [details setObject:sql forKey:SqfliteParamSql];
+            [details setObject:sql forKey:SqfliteSqlCipherParamSql];
             NSArray* sqlArguments = [operation getSqlArguments];
             if (sqlArguments != nil) {
-                [details setObject:sqlArguments forKey:SqfliteParamSqlArguments];
+                [details setObject:sqlArguments forKey:SqfliteSqlCipherParamSqlArguments];
             }
         }
         
@@ -252,9 +252,9 @@ static NSInteger _databaseOpenCount = 0;
     return dictionary;
 }
 
-- (bool)executeOrError:(SqfliteDatabase*)database fmdb:(FMDatabase*)db call:(FlutterMethodCall*)call result:(FlutterResult)result {
-    NSString* sql = call.arguments[SqfliteParamSql];
-    NSArray* arguments = call.arguments[SqfliteParamSqlArguments];
+- (bool)executeOrError:(SqfliteSqlCipherDatabase*)database fmdb:(FMDatabase*)db call:(FlutterMethodCall*)call result:(FlutterResult)result {
+    NSString* sql = call.arguments[SqfliteSqlCipherParamSql];
+    NSArray* arguments = call.arguments[SqfliteSqlCipherParamSqlArguments];
     NSArray* sqlArguments = [SqfliteSqlCipherPlugin toSqlArguments:arguments];
     BOOL argumentsEmpty = [SqfliteSqlCipherPlugin arrayIsEmpy:arguments];
     if (hasSqlLogLevel(database.logLevel)) {
@@ -275,7 +275,7 @@ static NSInteger _databaseOpenCount = 0;
     return true;
 }
 
-- (bool)executeOrError:(SqfliteDatabase*)database fmdb:(FMDatabase*)db operation:(SqfliteOperation*)operation {
+- (bool)executeOrError:(SqfliteSqlCipherDatabase*)database fmdb:(FMDatabase*)db operation:(SqfliteSqlCipherOperation*)operation {
     NSString* sql = [operation getSql];
     NSArray* sqlArguments = [operation getSqlArguments];
     NSNumber* inTransaction = [operation getInTransactionArgument];
@@ -315,7 +315,7 @@ static NSInteger _databaseOpenCount = 0;
 //
 // query
 //
-- (bool)query:(SqfliteDatabase*)database fmdb:(FMDatabase*)db operation:(SqfliteOperation*)operation {
+- (bool)query:(SqfliteSqlCipherDatabase*)database fmdb:(FMDatabase*)db operation:(SqfliteSqlCipherOperation*)operation {
     NSString* sql = [operation getSql];
     NSArray* sqlArguments = [operation getSqlArguments];
     BOOL argumentsEmpty = [SqfliteSqlCipherPlugin arrayIsEmpy:sqlArguments];
@@ -377,13 +377,13 @@ static NSInteger _databaseOpenCount = 0;
 }
 
 - (void)handleQueryCall:(FlutterMethodCall*)call result:(FlutterResult)result {
-    SqfliteDatabase* database = [self getDatabaseOrError:call result:result];
+    SqfliteSqlCipherDatabase* database = [self getDatabaseOrError:call result:result];
     if (database == nil) {
         return;
     }
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [database.fmDatabaseQueue inDatabase:^(FMDatabase *db) {
-            SqfliteMethodCallOperation* operation = [SqfliteMethodCallOperation newWithCall:call result:result];
+            SqfliteSqlCipherMethodCallOperation* operation = [SqfliteSqlCipherMethodCallOperation newWithCall:call result:result];
             [self query:database fmdb:db operation:operation];
         }];
     });
@@ -392,7 +392,7 @@ static NSInteger _databaseOpenCount = 0;
 //
 // insert
 //
-- (bool)insert:(SqfliteDatabase*)database fmdb:(FMDatabase*)db operation:(SqfliteOperation*)operation {
+- (bool)insert:(SqfliteSqlCipherDatabase*)database fmdb:(FMDatabase*)db operation:(SqfliteSqlCipherOperation*)operation {
     if (![self executeOrError:database fmdb:db operation:operation]) {
         return false;
     }
@@ -420,13 +420,13 @@ static NSInteger _databaseOpenCount = 0;
 
 - (void)handleInsertCall:(FlutterMethodCall*)call result:(FlutterResult)result {
     
-    SqfliteDatabase* database = [self getDatabaseOrError:call result:result];
+    SqfliteSqlCipherDatabase* database = [self getDatabaseOrError:call result:result];
     if (database == nil) {
         return;
     }
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [database.fmDatabaseQueue inDatabase:^(FMDatabase *db) {
-            SqfliteMethodCallOperation* operation = [SqfliteMethodCallOperation newWithCall:call result:result];
+            SqfliteSqlCipherMethodCallOperation* operation = [SqfliteSqlCipherMethodCallOperation newWithCall:call result:result];
             [self insert:database fmdb:db operation:operation];
         }];
     });
@@ -436,7 +436,7 @@ static NSInteger _databaseOpenCount = 0;
 //
 // update
 //
-- (bool)update:(SqfliteDatabase*)database fmdb:(FMDatabase*)db operation:(SqfliteOperation*)operation {
+- (bool)update:(SqfliteSqlCipherDatabase*)database fmdb:(FMDatabase*)db operation:(SqfliteSqlCipherOperation*)operation {
     if (![self executeOrError:database fmdb:db operation:operation]) {
         return false;
     }
@@ -453,14 +453,14 @@ static NSInteger _databaseOpenCount = 0;
 }
 
 - (void)handleUpdateCall:(FlutterMethodCall*)call result:(FlutterResult)result {
-    SqfliteDatabase* database = [self getDatabaseOrError:call result:result];
+    SqfliteSqlCipherDatabase* database = [self getDatabaseOrError:call result:result];
     if (database == nil) {
         return;
     }
     
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [database.fmDatabaseQueue inDatabase:^(FMDatabase *db) {
-            SqfliteMethodCallOperation* operation = [SqfliteMethodCallOperation newWithCall:call result:result];
+            SqfliteSqlCipherMethodCallOperation* operation = [SqfliteSqlCipherMethodCallOperation newWithCall:call result:result];
             [self update:database fmdb:db operation:operation];
         }];
     });
@@ -469,7 +469,7 @@ static NSInteger _databaseOpenCount = 0;
 //
 // execute
 //
-- (bool)execute:(SqfliteDatabase*)database fmdb:(FMDatabase*)db operation:(SqfliteOperation*)operation {
+- (bool)execute:(SqfliteSqlCipherDatabase*)database fmdb:(FMDatabase*)db operation:(SqfliteSqlCipherOperation*)operation {
     if (![self executeOrError:database fmdb:db operation:operation]) {
         return false;
     }
@@ -478,13 +478,13 @@ static NSInteger _databaseOpenCount = 0;
 }
 
 - (void)handleExecuteCall:(FlutterMethodCall*)call result:(FlutterResult)result {
-    SqfliteDatabase* database = [self getDatabaseOrError:call result:result];
+    SqfliteSqlCipherDatabase* database = [self getDatabaseOrError:call result:result];
     if (database == nil) {
         return;
     }
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [database.fmDatabaseQueue inDatabase:^(FMDatabase *db) {
-            SqfliteMethodCallOperation* operation = [SqfliteMethodCallOperation newWithCall:call result:result];
+            SqfliteSqlCipherMethodCallOperation* operation = [SqfliteSqlCipherMethodCallOperation newWithCall:call result:result];
             [self execute:database fmdb:db operation:operation];
         }];
     });
@@ -495,14 +495,14 @@ static NSInteger _databaseOpenCount = 0;
 // batch
 //
 - (void)handleBatchCall:(FlutterMethodCall*)call result:(FlutterResult)result {
-    SqfliteDatabase* database = [self getDatabaseOrError:call result:result];
+    SqfliteSqlCipherDatabase* database = [self getDatabaseOrError:call result:result];
     if (database == nil) {
         return;
     }
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [database.fmDatabaseQueue inDatabase:^(FMDatabase *db) {
             
-            SqfliteMethodCallOperation* mainOperation = [SqfliteMethodCallOperation newWithCall:call result:result];
+            SqfliteSqlCipherMethodCallOperation* mainOperation = [SqfliteSqlCipherMethodCallOperation newWithCall:call result:result];
             bool noResult = [mainOperation getNoResult];
             bool continueOnError = [mainOperation getContinueOnError];
             
@@ -511,7 +511,7 @@ static NSInteger _databaseOpenCount = 0;
             for (NSDictionary* dictionary in operations) {
                 // do something with object
                 
-                SqfliteBatchOperation* operation = [SqfliteBatchOperation new];
+                SqfliteSqlCipherBatchOperation* operation = [SqfliteSqlCipherBatchOperation new];
                 operation.dictionary = dictionary;
                 operation.noResult = noResult;
                 
@@ -613,7 +613,7 @@ static NSInteger _databaseOpenCount = 0;
     // The dart code is killed but the native code remains
     if (singleInstance) {
         @synchronized (self.mapLock) {
-            SqfliteDatabase* database = self.singleInstanceDatabaseMap[path];
+            SqfliteSqlCipherDatabase* database = self.singleInstanceDatabaseMap[path];
             if (database != nil) {
                 // Check if openedŸ
                 if (_log) {
@@ -659,7 +659,7 @@ static NSInteger _databaseOpenCount = 0;
     
     NSNumber* databaseId;
     @synchronized (self.mapLock) {
-        SqfliteDatabase* database = [SqfliteDatabase new];
+        SqfliteSqlCipherDatabase* database = [SqfliteSqlCipherDatabase new];
         databaseId = [NSNumber numberWithInteger:++_lastDatabaseId];
         database.inTransaction = false;
         database.fmDatabaseQueue = queue;
@@ -687,7 +687,7 @@ static NSInteger _databaseOpenCount = 0;
 // close
 //
 - (void)handleCloseDatabaseCall:(FlutterMethodCall*)call result:(FlutterResult)result {
-    SqfliteDatabase* database = [self getDatabaseOrError:call result:result];
+    SqfliteSqlCipherDatabase* database = [self getDatabaseOrError:call result:result];
     if (database == nil) {
         return;
     }
@@ -702,7 +702,7 @@ static NSInteger _databaseOpenCount = 0;
 //
 // close action
 //
-- (void)closeDatabase:(SqfliteDatabase*)database {
+- (void)closeDatabase:(SqfliteSqlCipherDatabase*)database {
     if (hasSqlLogLevel(database.logLevel)) {
         NSLog(@"closing %@", database.path);
     }
@@ -731,7 +731,7 @@ static NSInteger _databaseOpenCount = 0;
     
     // Handle hot-restart for single instance
     // The dart code is killed but the native code remains
-    SqfliteDatabase* database = nil;
+    SqfliteSqlCipherDatabase* database = nil;
     @synchronized (self.mapLock) {
         database = self.singleInstanceDatabaseMap[path];
         if (database != nil) {
@@ -767,7 +767,7 @@ static NSInteger _databaseOpenCount = 0;
         @synchronized (self.mapLock) {
             if ([self.databaseMap  count] > 0) {
                 NSMutableDictionary* dbsInfo     = [NSMutableDictionary new];
-                [self.databaseMap enumerateKeysAndObjectsUsingBlock:^(NSNumber * _Nonnull key, SqfliteDatabase * _Nonnull db, BOOL * _Nonnull stop) {
+                [self.databaseMap enumerateKeysAndObjectsUsingBlock:^(NSNumber * _Nonnull key, SqfliteSqlCipherDatabase * _Nonnull db, BOOL * _Nonnull stop) {
                     NSMutableDictionary* dbInfo	 = [NSMutableDictionary new];
                     [dbInfo setObject:db.path forKey:_paramPath];
                     [dbInfo setObject:[NSNumber numberWithBool:db.singleInstance] forKey:_paramSingleInstance];
@@ -820,7 +820,7 @@ static NSInteger _databaseOpenCount = 0;
     
     if (logLevelNumber) {
         logLevel = [logLevelNumber intValue];
-        NSLog(@"Sqflite: logLevel %d", logLevel);
+        NSLog(@"SqfliteSqlCipher: logLevel %d", logLevel);
     }
     result(nil);
 }

--- a/sqflite/ios/Classes/SqfliteSqlCipherPlugin.m
+++ b/sqflite/ios/Classes/SqfliteSqlCipherPlugin.m
@@ -654,7 +654,6 @@ static NSInteger _databaseOpenCount = 0;
         } else {
             [database setKey:password];
         }
-        NSLog(@"Encryption is ready.");
     }];
     
     NSNumber* databaseId;

--- a/sqflite/ios/sqflite_sqlcipher.podspec
+++ b/sqflite/ios/sqflite_sqlcipher.podspec
@@ -16,7 +16,7 @@ Access SQLite database.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'FMDB/SQLCipher', '~> 2.7.5'
-  s.dependency 'SQLCipher', '4.4.0'
+  s.dependency 'SQLCipher', '4.4.2'
   
   s.platform = :ios, '8.0'
   s.pod_target_xcconfig = {

--- a/sqflite/ios/sqflite_sqlcipher.podspec
+++ b/sqflite/ios/sqflite_sqlcipher.podspec
@@ -19,6 +19,10 @@ Access SQLite database.
   s.dependency 'SQLCipher', '4.4.0'
   
   s.platform = :ios, '8.0'
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'HEADER_SEARCH_PATHS' => 'SQLCipher',
+    'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64'
+  }
 end
 

--- a/sqflite/macos/Classes/SqfliteSqlCipherOperation.h
+++ b/sqflite/macos/Classes/SqfliteSqlCipherOperation.h
@@ -6,10 +6,10 @@
 //
 #import "SqfliteSqlCipherPlugin.h"
 
-#ifndef SqfliteOperation_h
-#define SqfliteOperation_h
+#ifndef SqfliteSqlCipherOperation_h
+#define SqfliteSqlCipherOperation_h
 
-@interface SqfliteOperation : NSObject
+@interface SqfliteSqlCipherOperation : NSObject
 
 - (NSString*)getMethod;
 - (NSString*)getSql;
@@ -22,7 +22,7 @@
 
 @end
 
-@interface SqfliteBatchOperation : SqfliteOperation
+@interface SqfliteSqlCipherBatchOperation : SqfliteSqlCipherOperation
 
 @property (atomic, retain) NSDictionary* dictionary;
 @property (atomic, retain) NSObject* results;
@@ -36,13 +36,13 @@
 
 @end
 
-@interface SqfliteMethodCallOperation : SqfliteOperation
+@interface SqfliteSqlCipherMethodCallOperation : SqfliteSqlCipherOperation
 
 @property (atomic, retain) FlutterMethodCall* flutterMethodCall;
 @property (atomic, assign) FlutterResult flutterResult;
 
-+ (SqfliteMethodCallOperation*)newWithCall:(FlutterMethodCall*)flutterMethodCall result:(FlutterResult)flutterResult;
++ (SqfliteSqlCipherMethodCallOperation*)newWithCall:(FlutterMethodCall*)flutterMethodCall result:(FlutterResult)flutterResult;
 
 @end
 
-#endif /* SqfliteOperation_h */
+#endif /* SqfliteSqlCipherOperation_h */

--- a/sqflite/macos/Classes/SqfliteSqlCipherOperation.m
+++ b/sqflite/macos/Classes/SqfliteSqlCipherOperation.m
@@ -6,11 +6,11 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "SqfliteOperation.h"
+#import "SqfliteSqlCipherOperation.h"
 #import "SqfliteSqlCipherPlugin.h"
 
 // Abstract
-@implementation SqfliteOperation
+@implementation SqfliteSqlCipherOperation
 
 - (NSString*)getMethod {
     return  nil;
@@ -36,25 +36,25 @@
 
 @end
 
-@implementation SqfliteBatchOperation
+@implementation SqfliteSqlCipherBatchOperation
 
 @synthesize dictionary, results, error, noResult, continueOnError;
 
 - (NSString*)getMethod {
-    return [dictionary objectForKey:SqfliteParamMethod];
+    return [dictionary objectForKey:SqfliteSqlCipherParamMethod];
 }
 
 - (NSString*)getSql {
-    return [dictionary objectForKey:SqfliteParamSql];
+    return [dictionary objectForKey:SqfliteSqlCipherParamSql];
 }
 
 - (NSArray*)getSqlArguments {
-    NSArray* arguments = [dictionary objectForKey:SqfliteParamSqlArguments];
+    NSArray* arguments = [dictionary objectForKey:SqfliteSqlCipherParamSqlArguments];
     return [SqfliteSqlCipherPlugin toSqlArguments:arguments];
 }
 
 - (NSNumber*)getInTransactionArgument {
-    return [dictionary objectForKey:SqfliteParamInTransaction];
+    return [dictionary objectForKey:SqfliteSqlCipherParamInTransaction];
 }
 
 - (bool)getNoResult {
@@ -77,7 +77,7 @@
     if (![self getNoResult]) {
         // We wrap the result in 'result' map
         [results addObject:[NSDictionary dictionaryWithObject:((self.results == nil) ? [NSNull null] : self.results)
-                                                       forKey:SqfliteParamResult]];
+                                                       forKey:SqfliteSqlCipherParamResult]];
     }
 }
 
@@ -86,15 +86,15 @@
     if (![self getNoResult]) {
         // We wrap the error in an 'error' map
         NSMutableDictionary* error = [NSMutableDictionary new];
-        error[SqfliteParamErrorCode] = self.error.code;
+        error[SqfliteSqlCipherParamErrorCode] = self.error.code;
         if (self.error.message != nil) {
-            error[SqfliteParamErrorMessage] = self.error.message;
+            error[SqfliteSqlCipherParamErrorMessage] = self.error.message;
         }
         if (self.error.details != nil) {
-            error[SqfliteParamErrorData] = self.error.details;
+            error[SqfliteSqlCipherParamErrorData] = self.error.details;
         }
         [results addObject:[NSDictionary dictionaryWithObject:error
-                                                       forKey:SqfliteParamError]];
+                                                       forKey:SqfliteSqlCipherParamError]];
     }
 }
 
@@ -104,13 +104,13 @@
 
 @end
 
-@implementation SqfliteMethodCallOperation
+@implementation SqfliteSqlCipherMethodCallOperation
 
 @synthesize flutterMethodCall;
 @synthesize flutterResult;
 
-+ (SqfliteMethodCallOperation*)newWithCall:(FlutterMethodCall*)flutterMethodCall result:(FlutterResult)flutterResult {
-    SqfliteMethodCallOperation* operation = [SqfliteMethodCallOperation new];
++ (SqfliteSqlCipherMethodCallOperation*)newWithCall:(FlutterMethodCall*)flutterMethodCall result:(FlutterResult)flutterResult {
+    SqfliteSqlCipherMethodCallOperation* operation = [SqfliteSqlCipherMethodCallOperation new];
     operation.flutterMethodCall = flutterMethodCall;
     operation.flutterResult = flutterResult;
     return operation;
@@ -121,26 +121,26 @@
 }
 
 - (NSString*)getSql {
-    return flutterMethodCall.arguments[SqfliteParamSql];
+    return flutterMethodCall.arguments[SqfliteSqlCipherParamSql];
 }
 
 - (bool)getNoResult {
-    NSNumber* noResult = flutterMethodCall.arguments[SqfliteParamNoResult];
+    NSNumber* noResult = flutterMethodCall.arguments[SqfliteSqlCipherParamNoResult];
     return [noResult boolValue];
 }
 
 - (bool)getContinueOnError {
-    NSNumber* noResult = flutterMethodCall.arguments[SqfliteParamContinueOnError];
+    NSNumber* noResult = flutterMethodCall.arguments[SqfliteSqlCipherParamContinueOnError];
     return [noResult boolValue];
 }
 
 - (NSArray*)getSqlArguments {
-    NSArray* arguments = flutterMethodCall.arguments[SqfliteParamSqlArguments];
+    NSArray* arguments = flutterMethodCall.arguments[SqfliteSqlCipherParamSqlArguments];
     return [SqfliteSqlCipherPlugin toSqlArguments:arguments];
 }
 
 - (NSNumber*)getInTransactionArgument {
-    return flutterMethodCall.arguments[SqfliteParamInTransaction];
+    return flutterMethodCall.arguments[SqfliteSqlCipherParamInTransaction];
 }
 
 - (void)success:(NSObject*)results {

--- a/sqflite/macos/Classes/SqfliteSqlCipherPlugin.h
+++ b/sqflite/macos/Classes/SqfliteSqlCipherPlugin.h
@@ -10,14 +10,14 @@
 
 @end
 
-extern NSString *const SqfliteParamMethod;
-extern NSString *const SqfliteParamSql;
-extern NSString *const SqfliteParamSqlArguments;
-extern NSString *const SqfliteParamInTransaction;
-extern NSString *const SqfliteParamNoResult;
-extern NSString *const SqfliteParamContinueOnError;
-extern NSString *const SqfliteParamResult;
-extern NSString *const SqfliteParamError;
-extern NSString *const SqfliteParamErrorCode;
-extern NSString *const SqfliteParamErrorMessage;
-extern NSString *const SqfliteParamErrorData;
+extern NSString *const SqfliteSqlCipherParamMethod;
+extern NSString *const SqfliteSqlCipherParamSql;
+extern NSString *const SqfliteSqlCipherParamSqlArguments;
+extern NSString *const SqfliteSqlCipherParamInTransaction;
+extern NSString *const SqfliteSqlCipherParamNoResult;
+extern NSString *const SqfliteSqlCipherParamContinueOnError;
+extern NSString *const SqfliteSqlCipherParamResult;
+extern NSString *const SqfliteSqlCipherParamError;
+extern NSString *const SqfliteSqlCipherParamErrorCode;
+extern NSString *const SqfliteSqlCipherParamErrorMessage;
+extern NSString *const SqfliteSqlCipherParamErrorData;

--- a/sqflite/macos/Classes/SqfliteSqlCipherPlugin.m
+++ b/sqflite/macos/Classes/SqfliteSqlCipherPlugin.m
@@ -8,7 +8,7 @@
 #endif
 
 #import <sqlite3.h>
-#import "SqfliteOperation.h"
+#import "SqfliteSqlCipherOperation.h"
 
 static NSString *const _channelName = @"com.davidmartos96.sqflite_sqlcipher";
 static NSString *const _inMemoryPath = @":memory:";
@@ -58,21 +58,21 @@ static NSString *const _paramCmd = @"cmd";
 static NSString *const _paramCmdGet = @"get";
 
 // Shared
-NSString *const SqfliteParamSql = @"sql";
-NSString *const SqfliteParamSqlArguments = @"arguments";
-NSString *const SqfliteParamInTransaction = @"inTransaction"; // true, false or null
-NSString *const SqfliteParamNoResult = @"noResult";
-NSString *const SqfliteParamContinueOnError = @"continueOnError";
-NSString *const SqfliteParamMethod = @"method";
+NSString *const SqfliteSqlCipherParamSql = @"sql";
+NSString *const SqfliteSqlCipherParamSqlArguments = @"arguments";
+NSString *const SqfliteSqlCipherParamInTransaction = @"inTransaction"; // true, false or null
+NSString *const SqfliteSqlCipherParamNoResult = @"noResult";
+NSString *const SqfliteSqlCipherParamContinueOnError = @"continueOnError";
+NSString *const SqfliteSqlCipherParamMethod = @"method";
 // For each operation in a batch, we have either a result or an error
-NSString *const SqfliteParamResult = @"result";
-NSString *const SqfliteParamError = @"error";
-NSString *const SqfliteParamErrorCode = @"code";
-NSString *const SqfliteParamErrorMessage = @"message";
-NSString *const SqfliteParamErrorData = @"data";
+NSString *const SqfliteSqlCipherParamResult = @"result";
+NSString *const SqfliteSqlCipherParamError = @"error";
+NSString *const SqfliteSqlCipherParamErrorCode = @"code";
+NSString *const SqfliteSqlCipherParamErrorMessage = @"message";
+NSString *const SqfliteSqlCipherParamErrorData = @"data";
 
 
-@interface SqfliteDatabase : NSObject
+@interface SqfliteSqlCipherDatabase : NSObject
 
 @property (atomic, retain) FMDatabaseQueue *fmDatabaseQueue;
 @property (atomic, retain) NSNumber *databaseId;
@@ -85,13 +85,13 @@ NSString *const SqfliteParamErrorData = @"data";
 
 @interface SqfliteSqlCipherPlugin ()
 
-@property (atomic, retain) NSMutableDictionary<NSNumber*, SqfliteDatabase*>* databaseMap;
-@property (atomic, retain) NSMutableDictionary<NSString*, SqfliteDatabase*>* singleInstanceDatabaseMap;
+@property (atomic, retain) NSMutableDictionary<NSNumber*, SqfliteSqlCipherDatabase*>* databaseMap;
+@property (atomic, retain) NSMutableDictionary<NSString*, SqfliteSqlCipherDatabase*>* singleInstanceDatabaseMap;
 @property (atomic, retain) NSObject* mapLock;
 
 @end
 
-@implementation SqfliteDatabase
+@implementation SqfliteSqlCipherDatabase
 
 @synthesize databaseId;
 @synthesize fmDatabaseQueue;
@@ -147,9 +147,9 @@ static NSInteger _databaseOpenCount = 0;
     return self;
 }
 
-- (SqfliteDatabase *)getDatabaseOrError:(FlutterMethodCall*)call result:(FlutterResult)result {
+- (SqfliteSqlCipherDatabase *)getDatabaseOrError:(FlutterMethodCall*)call result:(FlutterResult)result {
     NSNumber* databaseId = call.arguments[_paramId];
-    SqfliteDatabase* database = self.databaseMap[databaseId];
+    SqfliteSqlCipherDatabase* database = self.databaseMap[databaseId];
     if (database == nil) {
         NSLog(@"db not found.");
         result([FlutterError errorWithCode:_sqliteErrorCode
@@ -171,17 +171,17 @@ static NSInteger _databaseOpenCount = 0;
     return NO;
 }
 
-- (BOOL)handleError:(FMDatabase*)db operation:(SqfliteOperation*)operation {
+- (BOOL)handleError:(FMDatabase*)db operation:(SqfliteSqlCipherOperation*)operation {
     // handle error
     if ([db hadError]) {
         NSMutableDictionary* details = nil;
         NSString* sql = [operation getSql];
         if (sql != nil) {
             details = [NSMutableDictionary new];
-            [details setObject:sql forKey:SqfliteParamSql];
+            [details setObject:sql forKey:SqfliteSqlCipherParamSql];
             NSArray* sqlArguments = [operation getSqlArguments];
             if (sqlArguments != nil) {
-                [details setObject:sqlArguments forKey:SqfliteParamSqlArguments];
+                [details setObject:sqlArguments forKey:SqfliteSqlCipherParamSqlArguments];
             }
         }
         
@@ -252,9 +252,9 @@ static NSInteger _databaseOpenCount = 0;
     return dictionary;
 }
 
-- (bool)executeOrError:(SqfliteDatabase*)database fmdb:(FMDatabase*)db call:(FlutterMethodCall*)call result:(FlutterResult)result {
-    NSString* sql = call.arguments[SqfliteParamSql];
-    NSArray* arguments = call.arguments[SqfliteParamSqlArguments];
+- (bool)executeOrError:(SqfliteSqlCipherDatabase*)database fmdb:(FMDatabase*)db call:(FlutterMethodCall*)call result:(FlutterResult)result {
+    NSString* sql = call.arguments[SqfliteSqlCipherParamSql];
+    NSArray* arguments = call.arguments[SqfliteSqlCipherParamSqlArguments];
     NSArray* sqlArguments = [SqfliteSqlCipherPlugin toSqlArguments:arguments];
     BOOL argumentsEmpty = [SqfliteSqlCipherPlugin arrayIsEmpy:arguments];
     if (hasSqlLogLevel(database.logLevel)) {
@@ -275,7 +275,7 @@ static NSInteger _databaseOpenCount = 0;
     return true;
 }
 
-- (bool)executeOrError:(SqfliteDatabase*)database fmdb:(FMDatabase*)db operation:(SqfliteOperation*)operation {
+- (bool)executeOrError:(SqfliteSqlCipherDatabase*)database fmdb:(FMDatabase*)db operation:(SqfliteSqlCipherOperation*)operation {
     NSString* sql = [operation getSql];
     NSArray* sqlArguments = [operation getSqlArguments];
     NSNumber* inTransaction = [operation getInTransactionArgument];
@@ -315,7 +315,7 @@ static NSInteger _databaseOpenCount = 0;
 //
 // query
 //
-- (bool)query:(SqfliteDatabase*)database fmdb:(FMDatabase*)db operation:(SqfliteOperation*)operation {
+- (bool)query:(SqfliteSqlCipherDatabase*)database fmdb:(FMDatabase*)db operation:(SqfliteSqlCipherOperation*)operation {
     NSString* sql = [operation getSql];
     NSArray* sqlArguments = [operation getSqlArguments];
     BOOL argumentsEmpty = [SqfliteSqlCipherPlugin arrayIsEmpy:sqlArguments];
@@ -377,13 +377,13 @@ static NSInteger _databaseOpenCount = 0;
 }
 
 - (void)handleQueryCall:(FlutterMethodCall*)call result:(FlutterResult)result {
-    SqfliteDatabase* database = [self getDatabaseOrError:call result:result];
+    SqfliteSqlCipherDatabase* database = [self getDatabaseOrError:call result:result];
     if (database == nil) {
         return;
     }
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [database.fmDatabaseQueue inDatabase:^(FMDatabase *db) {
-            SqfliteMethodCallOperation* operation = [SqfliteMethodCallOperation newWithCall:call result:result];
+            SqfliteSqlCipherMethodCallOperation* operation = [SqfliteSqlCipherMethodCallOperation newWithCall:call result:result];
             [self query:database fmdb:db operation:operation];
         }];
     });
@@ -392,7 +392,7 @@ static NSInteger _databaseOpenCount = 0;
 //
 // insert
 //
-- (bool)insert:(SqfliteDatabase*)database fmdb:(FMDatabase*)db operation:(SqfliteOperation*)operation {
+- (bool)insert:(SqfliteSqlCipherDatabase*)database fmdb:(FMDatabase*)db operation:(SqfliteSqlCipherOperation*)operation {
     if (![self executeOrError:database fmdb:db operation:operation]) {
         return false;
     }
@@ -420,13 +420,13 @@ static NSInteger _databaseOpenCount = 0;
 
 - (void)handleInsertCall:(FlutterMethodCall*)call result:(FlutterResult)result {
     
-    SqfliteDatabase* database = [self getDatabaseOrError:call result:result];
+    SqfliteSqlCipherDatabase* database = [self getDatabaseOrError:call result:result];
     if (database == nil) {
         return;
     }
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [database.fmDatabaseQueue inDatabase:^(FMDatabase *db) {
-            SqfliteMethodCallOperation* operation = [SqfliteMethodCallOperation newWithCall:call result:result];
+            SqfliteSqlCipherMethodCallOperation* operation = [SqfliteSqlCipherMethodCallOperation newWithCall:call result:result];
             [self insert:database fmdb:db operation:operation];
         }];
     });
@@ -436,7 +436,7 @@ static NSInteger _databaseOpenCount = 0;
 //
 // update
 //
-- (bool)update:(SqfliteDatabase*)database fmdb:(FMDatabase*)db operation:(SqfliteOperation*)operation {
+- (bool)update:(SqfliteSqlCipherDatabase*)database fmdb:(FMDatabase*)db operation:(SqfliteSqlCipherOperation*)operation {
     if (![self executeOrError:database fmdb:db operation:operation]) {
         return false;
     }
@@ -453,14 +453,14 @@ static NSInteger _databaseOpenCount = 0;
 }
 
 - (void)handleUpdateCall:(FlutterMethodCall*)call result:(FlutterResult)result {
-    SqfliteDatabase* database = [self getDatabaseOrError:call result:result];
+    SqfliteSqlCipherDatabase* database = [self getDatabaseOrError:call result:result];
     if (database == nil) {
         return;
     }
     
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [database.fmDatabaseQueue inDatabase:^(FMDatabase *db) {
-            SqfliteMethodCallOperation* operation = [SqfliteMethodCallOperation newWithCall:call result:result];
+            SqfliteSqlCipherMethodCallOperation* operation = [SqfliteSqlCipherMethodCallOperation newWithCall:call result:result];
             [self update:database fmdb:db operation:operation];
         }];
     });
@@ -469,7 +469,7 @@ static NSInteger _databaseOpenCount = 0;
 //
 // execute
 //
-- (bool)execute:(SqfliteDatabase*)database fmdb:(FMDatabase*)db operation:(SqfliteOperation*)operation {
+- (bool)execute:(SqfliteSqlCipherDatabase*)database fmdb:(FMDatabase*)db operation:(SqfliteSqlCipherOperation*)operation {
     if (![self executeOrError:database fmdb:db operation:operation]) {
         return false;
     }
@@ -478,13 +478,13 @@ static NSInteger _databaseOpenCount = 0;
 }
 
 - (void)handleExecuteCall:(FlutterMethodCall*)call result:(FlutterResult)result {
-    SqfliteDatabase* database = [self getDatabaseOrError:call result:result];
+    SqfliteSqlCipherDatabase* database = [self getDatabaseOrError:call result:result];
     if (database == nil) {
         return;
     }
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [database.fmDatabaseQueue inDatabase:^(FMDatabase *db) {
-            SqfliteMethodCallOperation* operation = [SqfliteMethodCallOperation newWithCall:call result:result];
+            SqfliteSqlCipherMethodCallOperation* operation = [SqfliteSqlCipherMethodCallOperation newWithCall:call result:result];
             [self execute:database fmdb:db operation:operation];
         }];
     });
@@ -495,14 +495,14 @@ static NSInteger _databaseOpenCount = 0;
 // batch
 //
 - (void)handleBatchCall:(FlutterMethodCall*)call result:(FlutterResult)result {
-    SqfliteDatabase* database = [self getDatabaseOrError:call result:result];
+    SqfliteSqlCipherDatabase* database = [self getDatabaseOrError:call result:result];
     if (database == nil) {
         return;
     }
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [database.fmDatabaseQueue inDatabase:^(FMDatabase *db) {
             
-            SqfliteMethodCallOperation* mainOperation = [SqfliteMethodCallOperation newWithCall:call result:result];
+            SqfliteSqlCipherMethodCallOperation* mainOperation = [SqfliteSqlCipherMethodCallOperation newWithCall:call result:result];
             bool noResult = [mainOperation getNoResult];
             bool continueOnError = [mainOperation getContinueOnError];
             
@@ -511,7 +511,7 @@ static NSInteger _databaseOpenCount = 0;
             for (NSDictionary* dictionary in operations) {
                 // do something with object
                 
-                SqfliteBatchOperation* operation = [SqfliteBatchOperation new];
+                SqfliteSqlCipherBatchOperation* operation = [SqfliteSqlCipherBatchOperation new];
                 operation.dictionary = dictionary;
                 operation.noResult = noResult;
                 
@@ -613,7 +613,7 @@ static NSInteger _databaseOpenCount = 0;
     // The dart code is killed but the native code remains
     if (singleInstance) {
         @synchronized (self.mapLock) {
-            SqfliteDatabase* database = self.singleInstanceDatabaseMap[path];
+            SqfliteSqlCipherDatabase* database = self.singleInstanceDatabaseMap[path];
             if (database != nil) {
                 // Check if openedŸ
                 if (_log) {
@@ -659,7 +659,7 @@ static NSInteger _databaseOpenCount = 0;
     
     NSNumber* databaseId;
     @synchronized (self.mapLock) {
-        SqfliteDatabase* database = [SqfliteDatabase new];
+        SqfliteSqlCipherDatabase* database = [SqfliteSqlCipherDatabase new];
         databaseId = [NSNumber numberWithInteger:++_lastDatabaseId];
         database.inTransaction = false;
         database.fmDatabaseQueue = queue;
@@ -687,7 +687,7 @@ static NSInteger _databaseOpenCount = 0;
 // close
 //
 - (void)handleCloseDatabaseCall:(FlutterMethodCall*)call result:(FlutterResult)result {
-    SqfliteDatabase* database = [self getDatabaseOrError:call result:result];
+    SqfliteSqlCipherDatabase* database = [self getDatabaseOrError:call result:result];
     if (database == nil) {
         return;
     }
@@ -702,7 +702,7 @@ static NSInteger _databaseOpenCount = 0;
 //
 // close action
 //
-- (void)closeDatabase:(SqfliteDatabase*)database {
+- (void)closeDatabase:(SqfliteSqlCipherDatabase*)database {
     if (hasSqlLogLevel(database.logLevel)) {
         NSLog(@"closing %@", database.path);
     }
@@ -731,7 +731,7 @@ static NSInteger _databaseOpenCount = 0;
     
     // Handle hot-restart for single instance
     // The dart code is killed but the native code remains
-    SqfliteDatabase* database = nil;
+    SqfliteSqlCipherDatabase* database = nil;
     @synchronized (self.mapLock) {
         database = self.singleInstanceDatabaseMap[path];
         if (database != nil) {
@@ -767,7 +767,7 @@ static NSInteger _databaseOpenCount = 0;
         @synchronized (self.mapLock) {
             if ([self.databaseMap  count] > 0) {
                 NSMutableDictionary* dbsInfo     = [NSMutableDictionary new];
-                [self.databaseMap enumerateKeysAndObjectsUsingBlock:^(NSNumber * _Nonnull key, SqfliteDatabase * _Nonnull db, BOOL * _Nonnull stop) {
+                [self.databaseMap enumerateKeysAndObjectsUsingBlock:^(NSNumber * _Nonnull key, SqfliteSqlCipherDatabase * _Nonnull db, BOOL * _Nonnull stop) {
                     NSMutableDictionary* dbInfo	 = [NSMutableDictionary new];
                     [dbInfo setObject:db.path forKey:_paramPath];
                     [dbInfo setObject:[NSNumber numberWithBool:db.singleInstance] forKey:_paramSingleInstance];
@@ -820,7 +820,7 @@ static NSInteger _databaseOpenCount = 0;
     
     if (logLevelNumber) {
         logLevel = [logLevelNumber intValue];
-        NSLog(@"Sqflite: logLevel %d", logLevel);
+        NSLog(@"SqfliteSqlCipher: logLevel %d", logLevel);
     }
     result(nil);
 }

--- a/sqflite/macos/Classes/SqfliteSqlCipherPlugin.m
+++ b/sqflite/macos/Classes/SqfliteSqlCipherPlugin.m
@@ -654,7 +654,6 @@ static NSInteger _databaseOpenCount = 0;
         } else {
             [database setKey:password];
         }
-        NSLog(@"Encryption is ready.");
     }];
     
     NSNumber* databaseId;

--- a/sqflite/macos/sqflite_sqlcipher.podspec
+++ b/sqflite/macos/sqflite_sqlcipher.podspec
@@ -15,7 +15,7 @@ Access SQLite database.
   s.source_files     = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
   s.dependency 'FMDB/SQLCipher', '~> 2.7.5'
-  s.dependency 'SQLCipher', '4.4.0'
+  s.dependency 'SQLCipher', '4.4.2'
 
   s.platform = :osx, '10.11'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }

--- a/sqflite/pubspec.yaml
+++ b/sqflite/pubspec.yaml
@@ -2,7 +2,7 @@ name: sqflite_sqlcipher
 homepage: https://github.com/davidmartos96/sqflite_sqlcipher
 description: Flutter plugin for SQLite, a self-contained, high-reliability,
   embedded, SQL database engine. (SqlCipher support)
-version: 1.1.0+1
+version: 1.1.3
 
 environment:
   sdk: '>=2.6.0 <3.0.0'


### PR DESCRIPTION
Related to #19.

After #31 is merged, we can switch back the URL for `fmdb_override` in pubspec.