### PR TITLE
Remove NBSP

### DIFF
--- a/sqflite/ios/Classes/SqfliteSqlCipherPlugin.m
+++ b/sqflite/ios/Classes/SqfliteSqlCipherPlugin.m
@@ -651,7 +651,7 @@ static NSInteger _databaseOpenCount = 0;
     [queue inDatabase:^(FMDatabase *database) {
         if (password == nil) {
             [database setKey:@""];
-        } else {
+        } else {
             [database setKey:password];
         }
     }];


### PR DESCRIPTION
This replaces a `NBSP` with a regular space. This way, there will be no warning about it in the build log :) 


Log for reference
```
treating Unicode character as whitespace [-Wunicode-whitespace]
▸         } else {
▸               ^
```
