### PR TITLE
fix(ios/macos): don't register the database when the open password check fails

### DIFF
--- a/sqflite/ios/Classes/SqfliteSqlCipherPlugin.m
+++ b/sqflite/ios/Classes/SqfliteSqlCipherPlugin.m
@@ -648,6 +648,7 @@ static NSInteger _databaseOpenCount = 0;
         return;
     }
 
+    __block bool passwordCheckSucceeded = true;
     [queue inDatabase:^(FMDatabase *database) {
         if (password == nil) {
             [database setKey:@""];
@@ -658,12 +659,22 @@ static NSInteger _databaseOpenCount = 0;
         // Actually query the database in order to check the password is correct
         FMResultSet *s = [database executeQuery:@"SELECT COUNT(*) FROM sqlite_schema"];
         if (s == nil) {
-            result([FlutterError errorWithCode:_sqliteErrorCode
-                                       message:[NSString stringWithFormat:@"%@ %@", _errorOpenFailed, path]
-                                      details:nil]);
+            passwordCheckSucceeded = false;
             return;
         }
+        [s close];
     }];
+    
+    if (!passwordCheckSucceeded) {
+        // Do not register the keyless queue: a single-instance entry would be
+        // handed back (recovered:true) by the hot-restart branch to the next
+        // open of this path, with the key never applied.
+        [queue close];
+        result([FlutterError errorWithCode:_sqliteErrorCode
+                                   message:[NSString stringWithFormat:@"%@ %@", _errorOpenFailed, path]
+                                   details:nil]);
+        return;
+    }
     
     NSNumber* databaseId;
     @synchronized (self.mapLock) {

--- a/sqflite/macos/Classes/SqfliteSqlCipherPlugin.m
+++ b/sqflite/macos/Classes/SqfliteSqlCipherPlugin.m
@@ -648,6 +648,7 @@ static NSInteger _databaseOpenCount = 0;
         return;
     }
 
+    __block bool passwordCheckSucceeded = true;
     [queue inDatabase:^(FMDatabase *database) {
         if (password == nil) {
             [database setKey:@""];
@@ -658,12 +659,22 @@ static NSInteger _databaseOpenCount = 0;
         // Actually query the database in order to check the password is correct
         FMResultSet *s = [database executeQuery:@"SELECT COUNT(*) FROM sqlite_schema"];
         if (s == nil) {
-            result([FlutterError errorWithCode:_sqliteErrorCode
-                                       message:[NSString stringWithFormat:@"%@ %@", _errorOpenFailed, path]
-                                      details:nil]);
+            passwordCheckSucceeded = false;
             return;
         }
+        [s close];
     }];
+    
+    if (!passwordCheckSucceeded) {
+        // Do not register the keyless queue: a single-instance entry would be
+        // handed back (recovered:true) by the hot-restart branch to the next
+        // open of this path, with the key never applied.
+        [queue close];
+        result([FlutterError errorWithCode:_sqliteErrorCode
+                                   message:[NSString stringWithFormat:@"%@ %@", _errorOpenFailed, path]
+                                   details:nil]);
+        return;
+    }
     
     NSNumber* databaseId;
     @synchronized (self.mapLock) {


### PR DESCRIPTION
Fixes #122.

`handleOpenDatabaseCall` runs the eager password check inside `[queue inDatabase:^{...}]`. The failure path's `return` only exits the block, so the method fell through and still registered the keyless `FMDatabaseQueue` in `databaseMap` — and, for default `singleInstance: true` opens, in `singleInstanceDatabaseMap[path]` — then called `result()` a second time. The next `openDatabase()` of the same path hit the hot-restart recovery branch and got the keyless instance back: the correct password was never applied, and every statement failed with `Error Domain=FMDatabase Code=26 "file is not a database"`. Full analysis and repro in #122.

The change (identical in `sqflite/ios` and `sqflite/macos`):

- track the password-check outcome in a `__block` flag instead of answering from inside the block;
- on failure: close the queue, send the error once, and return **before** any registration;
- on success: close the check's `FMResultSet` (it was left open), then register and answer as before.

This matches the Android implementation, where a failed `Database.open()` throws before `databaseMap.put(...)` / `_singleInstancesByPath.put(...)`, so nothing is ever falsely registered.

**Verified on iPhone 17 simulator (iOS 26.5), Flutter 3.44.1 / Dart 3.12.1** with the integration test from #122:

- stock 3.4.0: keyed re-open after a failed keyless open returns the zombie → `SELECT` fails with code 26 (and the `singleInstance: false` control passes);
- with this patch: all tests pass — the wrong-password open still throws `open_failed` exactly as before, and the subsequent correct-key open works.
